### PR TITLE
Bugfix: Scout can now be compiled to Thumb

### DIFF
--- a/docs/tutorial_architecture_flags.txt
+++ b/docs/tutorial_architecture_flags.txt
@@ -60,7 +60,11 @@ Note: Can only be used with "SCOUT_EMBEDDED_ENV".
 
 Additional Flags - SCOUT_ARM_THUMB:
 -----------------------------------
-Meaning that scout will be executed on an ARM cpu in Thumb mode. This flag will be used only in PIC mode, in which we use inline assembly.
+Meaning that the code will be executed on an ARM cpu in Thumb mode. This flag will be used only in PIC mode, in which we use inline assembly.
+
+Additional Flags - SCOUT_LOADING_THUMB_CODE:
+--------------------------------------------
+Meaning that the loader will load a Scout that was compiled to be executed on an ARM cpu in Thumb mode.
 
 Additional Flags:
 -----------------

--- a/embedded_scout/compile_scout.py
+++ b/embedded_scout/compile_scout.py
@@ -71,6 +71,7 @@ def compileScoutLoader(logger):
     setTargetFlags(logger)
 
     # 2. Additional flags: thumb mode (if in ARM), and mmap (in both cases)
+    #  Note: If scout will also be in Thumb mode, add this flag too: flag_load_thumb
     setScoutFlags([flag_mmap] + ([flag_arc_thumb] if TARGET_ARCH == ARC_ARM else []))
 
     # 3. Define the working directories
@@ -110,7 +111,6 @@ def compileScout(logger):
     # 2. Add additional flags:
     #  a) Will use the TCP server for instructions
     #  b) Will use dynamic buffers (malloc) for the received instructions
-    #  c) If scout will also be in Thumb mode, add this flag too: flag_load_thumb
     setScoutFlags([flag_instructions, flag_dynamic_buffers])
 
     # 3. Define the working directories

--- a/embedded_scout/compile_scout.py
+++ b/embedded_scout/compile_scout.py
@@ -110,6 +110,7 @@ def compileScout(logger):
     # 2. Add additional flags:
     #  a) Will use the TCP server for instructions
     #  b) Will use dynamic buffers (malloc) for the received instructions
+    #  c) If scout will also be in Thumb mode, add this flag too: flag_load_thumb
     setScoutFlags([flag_instructions, flag_dynamic_buffers])
 
     # 3. Define the working directories

--- a/scout/loaders/tcp_client_loader.c
+++ b/scout/loaders/tcp_client_loader.c
@@ -58,7 +58,11 @@ void scout_main()
 #endif /* SCOUT_MMAP */
 
     /* Jump into the buffer */
+#ifdef SCOUT_LOADING_THUMB_CODE
+    ((void (*)(void))receiveBuffer + 1)();
+#else
     ((void (*)(void))receiveBuffer)();
+#endif /* SCOUT_LOADING_THUMB_CODE */
 
 free_resources:
 #ifdef SCOUT_RESTORE_FLOW

--- a/scout/loaders/tcp_server_loader.c
+++ b/scout/loaders/tcp_server_loader.c
@@ -70,7 +70,11 @@ void scout_main()
 #endif /* SCOUT_MMAP */
 
     /* Jump into the buffer */
+#ifdef SCOUT_LOADING_THUMB_CODE
+    ((void (*)(void))receiveBuffer + 1)();
+#else
     ((void (*)(void))receiveBuffer)();
+#endif /* SCOUT_LOADING_THUMB_CODE */
 
 free_resources:
 #ifdef SCOUT_RESTORE_FLOW

--- a/scout/pic/arm_pic_wrapper.c
+++ b/scout/pic/arm_pic_wrapper.c
@@ -36,7 +36,6 @@ void * get_live_address(const void * address)
     asm("mov    r0, %0              " : : "r" (address));
     asm("sub    r0, %0              " : : "r" (STATIC_FUNC_ADDR));
     asm("add    r0, r1              ");
-    asm("add    r0, #1              ");
 #else  /* SCOUT_BITS_64 */
     #error "Currently ARM 64bit is not supported :("
 #endif /* SCOUT_BITS_32 */

--- a/utils/scout_compiler.py
+++ b/utils/scout_compiler.py
@@ -57,6 +57,7 @@ flag_restore_flow   = 'SCOUT_RESTORE_FLOW'
 flag_dynamic_buffers= 'SCOUT_DYNAMIC_BUFFERS'
 flag_proxy          = 'SCOUT_PROXY'
 flag_mmap           = 'SCOUT_MMAP'
+flag_load_thumb     = 'SCOUT_LOADING_THUMB_CODE'
 
 # Using an enum to support feature extensions
 ARC_INTEL = 'intel'


### PR DESCRIPTION
Until now the loader could have been in Thumb mode, but Scout didn't.
Added a new flag: "SCOUT_LOADING_THUMB_MODE" to support this mode:
1) The loaders will jump to the scout's buffer + 1
2) The "get_live_address()" function had a duplicate "+1" in the calculation, it was removed