### PR TITLE
Bug Fix: get_live_address() fix in x64

### DIFF
--- a/scout/pic/intel_pic_wrapper.c
+++ b/scout/pic/intel_pic_wrapper.c
@@ -35,16 +35,8 @@ pic_context_t * get_context()
     asm("pop    %ecx                 ");
     asm("pop    %ebx                 ");
 #else  /* SCOUT_BITS_64 */
-    asm("push   %rbx                 ");
-    asm("push   %rcx                 ");
-    asm("lea    CONTEXT_LABEL, %rbx  ");
-    asm("call   get_pc               ");
-    asm("MEASURE_LABEL1:             ");
-    asm("lea    MEASURE_LABEL1, %rcx ");
-    asm("sub    %rcx, %rbx           ");
-    asm("add    %rbx, %rax           ");
-    asm("pop    %rcx                 ");
-    asm("pop    %rbx                 ");
+    /* Function pointers are stored in a PIC fashion by default in 64 bits */
+    asm("movq   %0, %%rax            " : : "r" ((addr_t)address));
 #endif /* SCOUT_BITS_32 */
 }
 


### PR DESCRIPTION
On x64, GCC by default compiles function pointers to be stored using
the actual RIP, instead of their static code address. Fixed Scout
accordingly, and now get_live_address() doesn't need to do a thing.