### PR TITLE
[docs] Bug-Fix: Sphinx needs requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx_rtd_theme


### PR DESCRIPTION
Added the requirements.txt file so readthedocs won't break.