### PR TITLE
[Bugfix] Restore arm-thumb support

### DIFF
--- a/utils/scout_compiler.py
+++ b/utils/scout_compiler.py
@@ -303,6 +303,9 @@ def generateCompilationFlags(compile_flags, link_flags, logger):
         else:
             basic_compile_flags += ['mbig-endian']
             basic_link_flags    += ['EB']
+        # Thumb
+        basic_compile_flags     += ['mthumb'] if (flag_arc_thumb in config_flags) else []
+
     # Endianness - Mips
     elif config_arc == flag_arc_mips:
         if config_endianness == flag_little_endian:
@@ -311,9 +314,6 @@ def generateCompilationFlags(compile_flags, link_flags, logger):
         else:
             basic_compile_flags += ['EB']
             basic_link_flags    += ['EB']
-
-        # Thumb
-        basic_compile_flags     += ['mthumb'] if (flag_arc_thumb in config_flags) else []
 
     # PC Environment
     if config_env == flag_env_pc:


### PR DESCRIPTION
The support stopped working due to a stupid indentation bug in the
compilation script. Fixes #22.